### PR TITLE
Timeout hotfix and improvements

### DIFF
--- a/lib/AddonSignals.py
+++ b/lib/AddonSignals.py
@@ -86,7 +86,7 @@ class SignalReceiver(xbmc.Monitor):
         self._slots[sender][signal](_decodeData(data))
 
 
-class CallHandler:
+class CallHandler(object):
     def __init__(self, signal, data, source_id, timeout=1000, use_timeout_exception=False):
         self.signal = signal
         self.data = data
@@ -103,6 +103,7 @@ class CallHandler:
         self.is_callback_received = True
 
     def waitForReturn(self):
+        monitor = xbmc.Monitor()
         end_time = _perf_clock() + (self.timeout / 1000)
         while not self.is_callback_received:
             if _perf_clock() > end_time:
@@ -110,6 +111,8 @@ class CallHandler:
                     unRegisterSlot(self.sourceID, self.signal)
                     raise TimeoutError
                 break
+            elif monitor.abortRequested():
+                raise OSError
             xbmc.sleep(10)
         unRegisterSlot(self.sourceID, self.signal)
         return self._return


### PR DESCRIPTION
This PR include a hotfix and three improvements

### Hotfix
After a long time i found the problem that plagued Netflix add-on library sync and normal use on slower devices or long operations.

The problem is caused from a wrong behaviour of waitForReturn method,
the calculation of time elapsed seems to be correct but it is not done correctly,
is particularly noticeable with high timeout values on linux with ARM devices.

I ran tests on a linux ARM device with timeout set to 20 seconds, these are the results:
Original AddonSignals:
<pre>
2020-07-09 14:02:31.640 T:3597636480   DEBUG: [plugin.video.netflix (1)] Execution time info for this run:
                                            make_call                      7684 ms
</pre>

Fixed AddonSignals:
<pre>
2020-07-09 14:09:06.093 T:3625513856   DEBUG: [plugin.video.netflix (1)] Execution time info for this run:
                                            make_call                     20002 ms
</pre>

This resolve my opened issue: https://github.com/ruuk/script.module.addon.signals/issues/11
Other tests has been made by other users from NF issue: https://github.com/CastagnaIT/plugin.video.netflix/issues/716

### Improvement 1
In the waitForReturn method, was used: `xbmc.sleep(100)` to delay the check,
the problem is that in the cycle it almost always happens that the data arrives at the time of sleep
so the delay will be reflected in the add-on that receives the data
so if an add-on makes 5 calls results of:
5 * 100ms = 500ms of total delay
10 * 100ms = 1 seconds of total delay
it might be okay if an add-on only makes a few calls (like 1, 2) but this slows down the whole add-on system
then now has been lowered to `xbmc.sleep(10)`

### Improvement 2
There is no system to really manage AddonSignals timeout in add-ons
so i have introduced the possibility of raising a timeout exception
as it should normally happen

This allows not only to better manage the timeout on add-ons side,
but allows you to return 'None' as value in the callback,
and thus avoid annoying workaroud for return empty values

### Improvement 3
There is a borderline case that when using high timeout values,
the original loop do not take in account when kodi is closed,
therefore Kodi terminate the other add-ons but remains in a catatonic state
because the script remains in the loops and preventing Kodi from stopping completely

i see now that Matrix branch is another,
so this PR need also a foreward to Matrix